### PR TITLE
deepdiff 6.7.1 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0001-Fix-encoding-error-on-Windows.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   # orjson is not available on s390x
   skip: true  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv


### PR DESCRIPTION
deepdiff 6.7.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5201]
- dev_url:        https://github.com/seperman/deepdiff/tree/6.7.1
- conda_forge:    None
- pypi:           n/a
- pypi inspector: n/a

### Explanation of changes:

- bump the build number
- point at the snowflake channel with `abs.yaml`


[PKG-5201]: https://anaconda.atlassian.net/browse/PKG-5201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ