### PR TITLE
deepdiff 7.0.1 (py313 rebuild)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "deepdiff" %}
 {% set version = "7.0.1" %}
-{% set sha256 = "260c16f052d4badbf60351b4f77e8390bee03a0b516246f6839bc813fb429ddf" %}
 
 package:
   name: {{ name|lower }}
@@ -8,21 +7,20 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 260c16f052d4badbf60351b4f77e8390bee03a0b516246f6839bc813fb429ddf
   patches:  # [win]
     - patches/0001-Fix-encoding-error-on-Windows.patch  # [win]
 
 build:
-  number: 0
-  # orjson is not available on s390x
-  skip: true  # [py<37 or s390x]
+  number: 1
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - deep = deepdiff.commands:cli
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
+  skip: true  # [py<37]
 
 requirements:
   build:
-    - m2-patch  # [win]
+    - msys2-patch  # [win]
   host:
     - pip
     - python
@@ -37,6 +35,12 @@ test:
   source_files:
     - tests
     - conftest.py
+  imports:
+    - deepdiff
+  commands:
+    - pip check
+    # Skip tests known to fail: https://github.com/seperman/deepdiff/issues/323
+    - pytest -v tests -k "not (test_serialization_text or test_deserialization or test_serialization_tree or test_deserialization_tree or test_delta_dump_and_read3 or delta_numpy7_arrays_of_different_sizes or test_diff_command)"
   requires:
     - pip
     - pytest
@@ -46,12 +50,6 @@ test:
     - python-dateutil
     - pydantic
     - tomli-w
-  commands:
-    - pip check
-    # Skip tests known to fail: https://github.com/seperman/deepdiff/issues/323
-    - pytest -v tests -k "not (test_serialization_text or test_deserialization or test_serialization_tree or test_deserialization_tree or test_delta_dump_and_read3 or delta_numpy7_arrays_of_different_sizes)"
-  imports:
-    - deepdiff
 
 about:
   home: https://github.com/seperman/deepdiff
@@ -70,3 +68,5 @@ extra:
     - loriab
     - seperman
     - synapticarbors
+  skip-lints:
+    - patch_unnecessary


### PR DESCRIPTION
deepdiff 7.0.1 

**Destination channel:** Defaults

### Links

- [PKG-9594]
- dev_url:        https://github.com/seperman/deepdiff/tree/7.0.1
- conda_forge:    https://github.com/conda-forge/deepdiff-feedstock
- pypi:           https://pypi.org/project/deepdiff/7.0.1
- pypi inspector: https://inspector.pypi.io/project/deepdiff/7.0.1

### Explanation of changes:

- new version number


[PKG-9594]: https://anaconda.atlassian.net/browse/PKG-9594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ