### PR TITLE
8.6.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "deepdiff" %}
-{% set version = "8.6.1" %}
+{% set version = "8.6.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a
+  sha256: 186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
@@ -48,8 +48,6 @@ requirements:
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_diff_other.py::TestDiffOther::test_repeated_timer" %}
 # >       assert "Module 'posix.system' is forbidden. You need to explicitly pass it by passing a safe_to_import parameter" == str(exc_info.value)
 {% set deselect_tests = deselect_tests + " --deselect=tests/test_security.py::TestDeltaClassPollution::test_remote_code_execution" %}  # [win]
-# Polars for py314 not exist yet, so that disable polars test for py314 only
-{% set deselect_tests = deselect_tests + " --deselect=tests/test_hash.py::TestDeepHashPrep::test_polars" %}  # [py==314]
 
 test:
   source_files:
@@ -70,7 +68,7 @@ test:
     - tomli-w >=1.2.0,<1.3.0
     - pandas >=2.2.0,<3.0.0
     - uuid6 >=2025.0.0
-    - polars >=1.21.0,<2.0.0  # [py<314]
+    - polars >=1.21.0,<2.0.0
   commands:
     - pip check
     - deep --help


### PR DESCRIPTION
deepdiff v8.6.2

**Destination channel:** defaults

### Links

- [PKG-13052](https://anaconda.atlassian.net/browse/PKG-13052) 
- [Upstream repository](https://github.com/qlustered/deepdiff)

### Explanation of changes:

- Bump version ans SHA
- Verified test skips are still required. 


[PKG-13052]: https://anaconda.atlassian.net/browse/PKG-13052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ